### PR TITLE
Fix adding types to build files

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import Redis from "ioredis";
+import {SegmentAnalytics} from "./index";
 
-const SegmentAnalytics = require("./index");
 const redis = new Redis();
 
 describe("segmentAnalytics test cases --->", SegmentAnalyticsTestCases);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ interface AnalyticsDataPayload {
   anonymousId?: string | null | undefined;
 }
 
-class SegmentAnalytics {
+export class SegmentAnalytics {
   /**
    * Initialize a new `Analytics` with your Segment project's `writeKey` and an
    * optional dictionary of `options`.
@@ -56,14 +56,14 @@ class SegmentAnalytics {
    *   @property {Number} [rateLimit] (default: 10)
    */
 
-  private apiKey: string;
-  private host: string;
-  private redisOptions: RedisOptions;
+  private readonly apiKey: string;
+  private readonly host: string;
+  private readonly redisOptions: RedisOptions;
 
   // The HTTP API has no hard rate limit.
   // However, Segment recommends not exceeding 500 requests per second, including large groups of events sent with a single batch request.
   // Always returns status 200 but if payload is too big, returns error 400
-  private queueRateLimit; // rate limit of queues
+  private readonly queueRateLimit; // rate limit of queues
   public identifyQueue: Bull.Queue<AnalyticsUserPayload>;
   public trackQueue: Bull.Queue<AnalyticsDataPayload>;
 
@@ -184,4 +184,3 @@ class SegmentAnalytics {
   }
 }
 
-module.exports = SegmentAnalytics;


### PR DESCRIPTION
Because we were using `molduls.export` and it's for nodejs not typescript it couldn't generate types when building js files, so I changed it to `export class ...`